### PR TITLE
Fixes #12 - Dependency clashes

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "packages/*"
   ],
   "devDependencies": {
-    "eslint": "^5.6.0",
+    "eslint": "^5.11.1",
     "jest": "^23.6.0",
     "jest-serializer-path": "^0.1.15",
     "lerna": "^3.8.1",

--- a/packages/browserslist-config/package.json
+++ b/packages/browserslist-config/package.json
@@ -16,6 +16,9 @@
   "publishConfig": {
     "access": "public"
   },
+  "engines": {
+    "node": "^8 || ^10 || ^11"
+  },
   "devDependencies": {
     "browserslist": "^4.3.7"
   }

--- a/packages/eslint-config-react/package.json
+++ b/packages/eslint-config-react/package.json
@@ -27,12 +27,12 @@
     "eslint": "^5.11.1",
     "eslint-plugin-compat": "^2.5.1",
     "eslint-plugin-import": "^2.14.0",
-    "eslint-plugin-react": "^7.12.1"
+    "eslint-plugin-react": "^7.12.2"
   },
   "peerDependencies": {
-    "eslint": "^5.6.0",
-    "eslint-plugin-compat": "^2.5.1",
-    "eslint-plugin-import": "^2.14.0",
-    "eslint-plugin-react": "^7.12.1"
+    "eslint": "^5.0.0",
+    "eslint-plugin-compat": "^2.0.0",
+    "eslint-plugin-import": "^2.0.0",
+    "eslint-plugin-react": "^7.0.0"
   }
 }

--- a/packages/eslint-config-react/package.json
+++ b/packages/eslint-config-react/package.json
@@ -21,10 +21,18 @@
     "node": "^8 || ^10 || ^11"
   },
   "dependencies": {
-    "@zonedigital/eslint-config-zone": "^3.1.0",
-    "eslint-plugin-react": "^7.11.1"
+    "@zonedigital/eslint-config-zone": "^3.1.0"
   },
   "devDependencies": {
-    "eslint": "^5.6.0"
+    "eslint": "^5.11.1",
+    "eslint-plugin-compat": "^2.5.1",
+    "eslint-plugin-import": "^2.14.0",
+    "eslint-plugin-react": "^7.12.1"
+  },
+  "peerDependencies": {
+    "eslint": "^5.6.0",
+    "eslint-plugin-compat": "^2.5.1",
+    "eslint-plugin-import": "^2.14.0",
+    "eslint-plugin-react": "^7.11.1"
   }
 }

--- a/packages/eslint-config-react/package.json
+++ b/packages/eslint-config-react/package.json
@@ -33,6 +33,6 @@
     "eslint": "^5.6.0",
     "eslint-plugin-compat": "^2.5.1",
     "eslint-plugin-import": "^2.14.0",
-    "eslint-plugin-react": "^7.11.1"
+    "eslint-plugin-react": "^7.12.1"
   }
 }

--- a/packages/eslint-config-react/package.json
+++ b/packages/eslint-config-react/package.json
@@ -17,6 +17,9 @@
   "publishConfig": {
     "access": "public"
   },
+  "engines": {
+    "node": "^8 || ^10 || ^11"
+  },
   "dependencies": {
     "@zonedigital/eslint-config-zone": "^3.1.0",
     "eslint-plugin-react": "^7.11.1"

--- a/packages/eslint-config-vue/package.json
+++ b/packages/eslint-config-vue/package.json
@@ -21,10 +21,18 @@
     "node": "^8 || ^10 || ^11"
   },
   "dependencies": {
-    "@zonedigital/eslint-config-zone": "^3.1.0",
-    "eslint-plugin-vue": "^5.1.0"
+    "@zonedigital/eslint-config-zone": "^3.1.0"
   },
   "devDependencies": {
-    "eslint": "^5.6.0"
+    "eslint": "^5.11.1",
+    "eslint-plugin-compat": "^2.5.1",
+    "eslint-plugin-import": "^2.14.0",
+    "eslint-plugin-vue": "^5.1.0"
+  },
+  "peerDependencies": {
+    "eslint": "^5.6.0",
+    "eslint-plugin-compat": "^2.5.1",
+    "eslint-plugin-import": "^2.14.0",
+    "eslint-plugin-vue": "^5.1.0"
   }
 }

--- a/packages/eslint-config-vue/package.json
+++ b/packages/eslint-config-vue/package.json
@@ -17,6 +17,9 @@
   "publishConfig": {
     "access": "public"
   },
+  "engines": {
+    "node": "^8 || ^10 || ^11"
+  },
   "dependencies": {
     "@zonedigital/eslint-config-zone": "^3.1.0",
     "eslint-plugin-vue": "^5.1.0"

--- a/packages/eslint-config-vue/package.json
+++ b/packages/eslint-config-vue/package.json
@@ -30,9 +30,9 @@
     "eslint-plugin-vue": "^5.1.0"
   },
   "peerDependencies": {
-    "eslint": "^5.6.0",
-    "eslint-plugin-compat": "^2.5.1",
-    "eslint-plugin-import": "^2.14.0",
+    "eslint": "^5.0.0",
+    "eslint-plugin-compat": "^2.0.0",
+    "eslint-plugin-import": "^2.0.0",
     "eslint-plugin-vue": "^5.1.0"
   }
 }

--- a/packages/eslint-config-zone/package.json
+++ b/packages/eslint-config-zone/package.json
@@ -28,8 +28,8 @@
     "eslint-plugin-import": "^2.14.0"
   },
   "peerDependencies": {
-    "eslint": "^5.6.0",
-    "eslint-plugin-compat": "^2.5.1",
-    "eslint-plugin-import": "^2.14.0"
+    "eslint": "^5.0.0",
+    "eslint-plugin-compat": "^2.0.0",
+    "eslint-plugin-import": "^2.0.0"
   }
 }

--- a/packages/eslint-config-zone/package.json
+++ b/packages/eslint-config-zone/package.json
@@ -20,8 +20,15 @@
     "node": "^8 || ^10 || ^11"
   },
   "dependencies": {
+    "eslint-config-airbnb-base": "^13.1.0"
+  },
+  "devDependencies": {
+    "eslint": "^5.11.1",
+    "eslint-plugin-compat": "^2.5.1",
+    "eslint-plugin-import": "^2.14.0"
+  },
+  "peerDependencies": {
     "eslint": "^5.6.0",
-    "eslint-config-airbnb-base": "^13.1.0",
     "eslint-plugin-compat": "^2.5.1",
     "eslint-plugin-import": "^2.14.0"
   }

--- a/packages/eslint-config-zone/package.json
+++ b/packages/eslint-config-zone/package.json
@@ -16,6 +16,9 @@
   "publishConfig": {
     "access": "public"
   },
+  "engines": {
+    "node": "^8 || ^10 || ^11"
+  },
   "dependencies": {
     "eslint": "^5.6.0",
     "eslint-config-airbnb-base": "^13.1.0",

--- a/packages/jarvis/package.json
+++ b/packages/jarvis/package.json
@@ -18,6 +18,9 @@
   "publishConfig": {
     "access": "public"
   },
+  "engines": {
+    "node": "^8 || ^10 || ^11"
+  },
   "bin": "./index.js",
   "eslintConfig": {
     "env": {

--- a/packages/stylelint-config-zone/package.json
+++ b/packages/stylelint-config-zone/package.json
@@ -16,6 +16,9 @@
   "publishConfig": {
     "access": "public"
   },
+  "engines": {
+    "node": "^8 || ^10 || ^11"
+  },
   "dependencies": {
     "stylelint": "^9.5.0",
     "stylelint-config-standard": "^18.2.0"

--- a/packages/stylelint-config-zone/package.json
+++ b/packages/stylelint-config-zone/package.json
@@ -20,7 +20,12 @@
     "node": "^8 || ^10 || ^11"
   },
   "dependencies": {
-    "stylelint": "^9.5.0",
     "stylelint-config-standard": "^18.2.0"
+  },
+  "devDependencies": {
+    "stylelint": "^9.5.0"
+  },
+  "peerDependencies": {
+    "stylelint": "^9.5.0"
   }
 }

--- a/packages/stylelint-config-zone/package.json
+++ b/packages/stylelint-config-zone/package.json
@@ -26,6 +26,6 @@
     "stylelint": "^9.5.0"
   },
   "peerDependencies": {
-    "stylelint": "^9.5.0"
+    "stylelint": "^9.0.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2178,7 +2178,7 @@ error-ex@^1.2.0, error-ex@^1.3.1:
   dependencies:
     is-arrayish "^0.2.1"
 
-es-abstract@^1.5.1, es-abstract@^1.6.1, es-abstract@^1.7.0:
+es-abstract@^1.11.0, es-abstract@^1.5.1, es-abstract@^1.6.1, es-abstract@^1.7.0:
   version "1.12.0"
   resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.12.0.tgz#9dbbdd27c6856f0001421ca18782d786bf8a6165"
   integrity sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==
@@ -2278,16 +2278,18 @@ eslint-plugin-import@^2.14.0:
     read-pkg-up "^2.0.0"
     resolve "^1.6.0"
 
-eslint-plugin-react@^7.11.1:
-  version "7.11.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.11.1.tgz#c01a7af6f17519457d6116aa94fc6d2ccad5443c"
-  integrity sha512-cVVyMadRyW7qsIUh3FHp3u6QHNhOgVrLQYdQEB1bPWBsgbNCHdFAeNMquBMCcZJu59eNthX053L70l7gRt4SCw==
+eslint-plugin-react@^7.12.1:
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.12.1.tgz#b9c4639f72469ff317ac31e3bd630d22d0dbf8f4"
+  integrity sha512-1YyXVhp6KSB+xRC1BWzmlA4BH9Wp9jMMBE6AJizxuk+bg/KUJpQGRwsU1/q1pV8rM6oEdLCxunXn7Nfh2BOWBg==
   dependencies:
     array-includes "^3.0.3"
     doctrine "^2.1.0"
     has "^1.0.3"
     jsx-ast-utils "^2.0.1"
+    object.fromentries "^2.0.0"
     prop-types "^15.6.2"
+    resolve "^1.9.0"
 
 eslint-plugin-vue@^5.1.0:
   version "5.1.0"
@@ -2319,10 +2321,10 @@ eslint-visitor-keys@^1.0.0:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#3f3180fb2e291017716acb4c9d6d5b5c34a6a81d"
   integrity sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==
 
-eslint@^5.6.0:
-  version "5.10.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-5.10.0.tgz#24adcbe92bf5eb1fc2d2f2b1eebe0c5e0713903a"
-  integrity sha512-HpqzC+BHULKlnPwWae9MaVZ5AXJKpkxCVXQHrFaRw3hbDj26V/9ArYM4Rr/SQ8pi6qUPLXSSXC4RBJlyq2Z2OQ==
+eslint@^5.11.1:
+  version "5.11.1"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-5.11.1.tgz#8deda83db9f354bf9d3f53f9677af7e0e13eadda"
+  integrity sha512-gOKhM8JwlFOc2acbOrkYR05NW8M6DCMSvfcJiBB5NDxRE1gv8kbvxKaC9u69e6ZGEMWXcswA/7eKR229cEIpvg==
   dependencies:
     "@babel/code-frame" "^7.0.0"
     ajv "^6.5.3"
@@ -5209,6 +5211,16 @@ object.entries@^1.0.4:
     function-bind "^1.1.0"
     has "^1.0.1"
 
+object.fromentries@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/object.fromentries/-/object.fromentries-2.0.0.tgz#49a543d92151f8277b3ac9600f1e930b189d30ab"
+  integrity sha512-9iLiI6H083uiqUuvzyY6qrlmc/Gz8hLQFOcb/Ri/0xXFkSNS3ctV+CbE6yM2+AnkYfOB3dGjdzC0wrMLIhQICA==
+  dependencies:
+    define-properties "^1.1.2"
+    es-abstract "^1.11.0"
+    function-bind "^1.1.1"
+    has "^1.0.1"
+
 object.getownpropertydescriptors@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz#8758c846f5b407adab0f236e0986f14b051caa16"
@@ -5527,7 +5539,7 @@ path-key@^2.0.0, path-key@^2.0.1:
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
   integrity sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=
 
-path-parse@^1.0.5:
+path-parse@^1.0.5, path-parse@^1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
   integrity sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==
@@ -6243,6 +6255,13 @@ resolve@^1.3.2, resolve@^1.5.0, resolve@^1.6.0:
   integrity sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==
   dependencies:
     path-parse "^1.0.5"
+
+resolve@^1.9.0:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.9.0.tgz#a14c6fdfa8f92a7df1d996cb7105fa744658ea06"
+  integrity sha512-TZNye00tI67lwYvzxCxHGjwTNlUV70io54/Ed4j6PscB8xVfuBJpRenI/o6dVk0cY0PYTY27AgCoGGxRnYuItQ==
+  dependencies:
+    path-parse "^1.0.6"
 
 restore-cursor@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
<!--
When resolving a specific issue, reference the issue in the PR's title (e.g. `Fixes #xx[, #xx]`, where "xx" is the issue number).
-->

**What does this PR cover?**
Bugfix

**Breaking change?**
Yes

**Are all the tests are passing?**
No

**Other information:**
- Support node engines not specified in `package.json` to match CI build targets.
- Reverted back to peer dependencies
- Updating `eslint` and `eslint-plugin-react` to latest
- Resolving conflicts
- Tweaking peer dependencies to offer greater compatibility