### PR TITLE
Removing greenkeeper

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,3 @@ branches:
     - master
     - develop
     - /^release/
-    - /^greenkeeper/.*$/

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Zone: Frontend
 
-[![Part of Zone Frontend][zone-fe-image]][zone-fe-url] [![Travis][img-travis]][url-travis] [![lerna][img-lerna]][url-lerna] [![License][img-license]][url-license] [![Greenkeeper][img-greenkeeper]][url-greenkeeper]
+[![Part of Zone Frontend][zone-fe-image]][zone-fe-url] [![Travis][img-travis]][url-travis] [![lerna][img-lerna]][url-lerna] [![License][img-license]][url-license]
 
 Mono repo for Zone's frontend setup and tooling.
 
@@ -39,12 +39,10 @@ Be sure to check that all the [Travis CI][url-travis] build jobs have passed.
 [eslint-config-zone]: https://github.com/zone/frontend/tree/master/packages/eslint-config-zone
 [zoneify]: https://github.com/zone/frontend/tree/master/packages/zoneify
 [stylelint-config-zone]: https://github.com/zone/frontend/tree/master/packages/stylelint-config-zone
-[img-greenkeeper]: https://badges.greenkeeper.io/zone/frontend.svg?style=flat-square
 [img-lerna]: https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg?style=flat-square
 [img-license]: https://img.shields.io/badge/license-MIT-blue.svg?style=flat-square
 [img-travis]: https://img.shields.io/travis/zone/frontend.svg?style=flat-square
 [img-zone]: .github/logo.svg
-[url-greenkeeper]: https://greenkeeper.io/
 [url-lerna]: https://lernajs.io/
 [url-license]: https://github.com/zonedigital/frontend/blob/master/LICENSE
 [url-travis]: https://travis-ci.org/zone/frontend


### PR DESCRIPTION
<!--
When resolving a specific issue, reference the issue in the PR's title (e.g. `Fixes #xx[, #xx]`, where "xx" is the issue number).
-->

**What does this PR cover?**
Chore - Greenkeeper is being discontinued, therefore removing. GitHub provides dependabot for dependency updates alongside the security alerts.

**Breaking change?**
No

**Are all the tests are passing?**
Yes

**Other information:**
