### PR TITLE
feature/update-eslint-react-dep

### DIFF
--- a/packages/eslint-config-zone/package.json
+++ b/packages/eslint-config-zone/package.json
@@ -26,7 +26,7 @@
     "eslint-config-airbnb-base": "^14.0.0",
     "eslint-config-prettier": "^6.4.0",
     "eslint-plugin-compat": "^3.0.0",
-    "eslint-plugin-import": "^2.14.0",
+    "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-prettier": "^3.1.1"
   },
   "devDependencies": {


### PR DESCRIPTION
updating eslint-plug-import to fix an issue with infinite peer dependency from airbnb linting.

```
package.json » @zonedigital/eslint-config-react » @zonedigital/eslint-config-zone » eslint-config-airbnb-base 
Configuration for rule "import/no-cycle" is invalid:
	Value "∞" should be integer.
```


**Breaking change?**
No

**Are all the tests are passing?**
Yes


